### PR TITLE
Fix parsing of exports that do not contain values.

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function line (l) {
   if (m && m[2]) {
     return {
       name: m[2].trim(),
-      value: m[3].trim()
+      value: m[3] ? m[3].trim() : ''
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -13,6 +13,7 @@ test('line', function (t) {
     t.deepEqual(index.line('  FOO  = BAR'), {name: 'FOO', value: 'BAR'})
     t.deepEqual(index.line('exported = Yes  '), {name: 'exported', value: 'Yes'})
     t.deepEqual(index.line('export ed = Yes  '), {name: 'ed', value: 'Yes'})
+    t.deepEqual(index.line('export A='), {name: 'A', value: ''})
 
     t.end()
 })


### PR DESCRIPTION
This commit fixes the case of missing values in export statements such as:

```
export SOME_KEY=
```

Node should be reading this as '', as seen when running the below.

```
(bash)$ SOME_KEY= node
(node)> process.env.SOME_KEY // ''
(node)> process.env.OTHER_KEY // undefined
```